### PR TITLE
chore(deps): bump actions/setup-python from 4 to 5

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ runs:
         install-aws: ${{ env.INSTALL_AWS }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: "poetry"


### PR DESCRIPTION
GitHub generates warning when using `actions/setup-python@v4`:

> [!WARNING] 
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 

This PR updates setup-python action to [v5](https://github.com/actions/setup-python/releases/tag/v5.0.0) which uses node20